### PR TITLE
Refactor filter methods and tests

### DIFF
--- a/src/classes/RecipeRepository.js
+++ b/src/classes/RecipeRepository.js
@@ -24,49 +24,58 @@ class RecipeRepository {
   };
 
   getIngredientID(ingName, ingredientsData) {
-    const ingNameLC = ingName.toLowerCase();
-    const ingredientIDFromSearch = ingredientsData.filter((ingredient) => {
-      return ingredient.name === ingNameLC;
-    }).map((ingredient) => {
-      return ingredient.id;
-    });
+    // old version:
+    // const ingNameLC = ingName.toLowerCase();
+    // const ingredientIDFromSearch = ingredientsData.filter((ingredient) => {
+    //   return ingredient.name === ingNameLC;
+    // }).map((ingredient) => {
+    //   return ingredient.id;
+    // });
+    //
+    // return ingredientIDFromSearch
 
+    // refacorted version: returns just the ID number, insted of [ID number]
+    const ingNameLC = ingName.toLowerCase();
+    const ingredientIDFromSearch = ingredientsData.reduce((acc, ingredient) => {
+      if (ingredient.name === ingNameLC) {
+        acc = ingredient.id;
+      };
+      return acc;
+    }, 0);
     return ingredientIDFromSearch
   };
 
   filterByIng(nameOrIng, ingredientsData) {
     const ingredientID = this.getIngredientID(nameOrIng, ingredientsData);
-    const recipesByIngID = this.recipeData.filter((recipe) => {
+    return this.recipeData.filter((recipe) => {
       let ingIDs = recipe.ingredients.map((ingredient) => {
         return ingredient.id;
       });
-      return ingIDs.includes(ingredientID[0]);
-    });
+      return ingIDs.includes(ingredientID);
+    })
 
-    return recipesByIngID.forEach(recipe => {
-      this.recipesToShow.push(recipe);
-    });
   };
 
   filterByName(nameOrIng, ingredientsData) {
-    const recipesByName = this.recipeData.filter((recipe) => {
+    return this.recipeData.filter((recipe) => {
       return recipe.name.toLowerCase().includes(nameOrIng.toLowerCase());
-    });
-
-    const recipesToShowLC = this.recipesToShow.map((recipe) => {
-      return recipe.name.toLowerCase();
-    });
-
-    const recipesByNameNoDuplicates = recipesByName.filter(recipe => {
-      return !recipesToShowLC.includes(recipe.name);
-    }).forEach(recipe => {this.recipesToShow.push(recipe)});
+    })
   };
 
   filterByNameOrIng(nameOrIng, ingredientsData) {
     this.recipesToShow = [];
-    this.filterByIng(nameOrIng, ingredientsData);
-    this.filterByName(nameOrIng, ingredientsData);
-    return this.recipesToShow;
+    let recipesByIng = this.filterByIng(nameOrIng, ingredientsData);
+    let recipesByName = this.filterByName(nameOrIng, ingredientsData);
+
+    recipesByIng.forEach(recipe => {
+      this.recipesToShow.push(recipe);
+    });
+
+    recipesByName.forEach(recipe => {
+      if (!this.recipesToShow.includes(recipe)) {
+        this.recipesToShow.push(recipe)
+      };
+    });
   };
 };
 

--- a/test/RecipeRepository-test.js
+++ b/test/RecipeRepository-test.js
@@ -48,28 +48,42 @@ describe('RecipeRepository', () => {
     expect(recipesByTag).to.deep.equal([sampleData[0], sampleData[2], sampleData[7]]);
   });
 
-  it('should be able to take in an ingredient name and return an array containing that ingredients ID', () => {
-    const getIngID = repository.getIngredientID('wheat flour', ingredientsData);
+  it('should be able to take in an ingredient name and return the corresponding ID for that ingredient', () => {
+    const ingID = repository.getIngredientID('wheat flour', ingredientsData);
 
-    expect(getIngID).to.deep.equal([20081])
+    expect(ingID).to.deep.equal(20081)
   });
 
   it('should return a list of recipes based on its name', () => {
-    const recipesByName = repository.filterByNameOrIng('Loaded Chocolate Chip Pudding Cookie Cups', ingredientsData);
-    let recipe1 = sampleData[0];
-    let recipesTest = [recipe1];
+    let recipesByName = repository.filterByName('Loaded Chocolate Chip Pudding Cookie Cups', ingredientsData);
+
+    let recipesTest = [sampleData[0]];
 
     expect(recipesByName).to.deep.equal(recipesTest);
   });
 
   it('should return a list of recipes based on its ingredient', () => {
-    const recipesByIngredient = repository.filterByNameOrIng('brown sugar', ingredientsData);
+    let recipesByIng = repository.filterByIng('brown sugar', ingredientsData);
+
     let recipe1 = sampleData[0];
     let recipe2 = sampleData[2];
     let recipe3 = sampleData[6];
     let recipe4 = sampleData[8];
+
     let recipesTest = [recipe1, recipe2, recipe3, recipe4];
 
-    expect(recipesByIngredient).to.deep.equal(recipesTest);
+    expect(recipesByIng).to.deep.equal(recipesTest);
   });
+
+  // these test to make sure we are not adding duplicates, we can choose one I just wanted to try multiple cases
+  it('should be able to filter by name or ingredient and store result', () => {
+    repository.filterByNameOrIng('coconut', ingredientsData);
+    expect(repository.recipesToShow).to.deep.equal([sampleData[6]]);
+
+    repository.filterByNameOrIng('pineapple', ingredientsData);
+    expect(repository.recipesToShow).to.deep.equal([sampleData[8]]);
+
+    repository.filterByNameOrIng('rapini', ingredientsData);
+    expect(repository.recipesToShow).to.deep.equal([sampleData[9]]);
+  })
 });


### PR DESCRIPTION
#### What's this PR do?
Refactored RecipeRepo methods: 
- getIngredientID: used reduce to make it return just the ingredient ID instead of [ingredient ID]
- filterByIng: made it DRYer, this function returns an array of recipes by ing (does not add them to recipesToShow property, just determines which ones need to be added)
- filterByName: made it DRYer and single purpose, this function return an array of recipes by name (does not add them to recipesToShow property, just determines which ones need to be added)
- filterByNameOrIng: made it DRYer and single purpose, this function works by: calling filterByIng and filterByName, pushes all recipes in filterByName to recipesToShow, pushes recipes from filterByName to recipesToShow if they are not duplicates

- Refactored tests for filterByIng and filterByName to work appropriately with the changes I made
- added a test specifically for the filterByNameOrIng function. This test looks at scenarios where a recipe would appear in both the filterByName and filterByIng lists, so it makes sure that recipes are not duplicated. I have 3 different scenarios in there for now, but we could reduce to just test one scenario 

#### Where should the reviewer start?
- line 26 of RecipeRepository (I refactored all methods from there on)
- line 51 of RecipeRepository-test (I refactored all methods from there on)

#### How should this be manually tested?
run npm test (all tests are passing)
can add in console logs to functions/test to see how they are working 

#### Any background context you want to provide?
the purpose of these changes are to make our RecipeRepo more readable and make each method single purpose 

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A